### PR TITLE
Extended to support an existing VNet

### DIFF
--- a/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/Deploy-AzureResourceGroup.ps1
+++ b/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/Deploy-AzureResourceGroup.ps1
@@ -1,0 +1,117 @@
+#Requires -Version 3.0
+#Requires -Module AzureRM.Resources
+#Requires -Module Azure.Storage
+
+Param(
+    [string] [Parameter(Mandatory=$true)] $ResourceGroupLocation,
+    [string] $ResourceGroupName = 'SAP-Hana-IaaC',
+    [string] $StorageAccountName,
+    [string] $StorageContainerName = $ResourceGroupName.ToLowerInvariant() + '-stageartifacts',
+    [string] $TemplateFile = 'azuredeploy.json',
+    [string] $TemplateParametersFile = 'azuredeploy.parameters.json',
+    [string] $ArtifactStagingDirectory = '.',
+    [string] $DSCSourceFolder = 'DSC',
+    [switch] $ValidateOnly
+)
+
+try {
+    [Microsoft.Azure.Common.Authentication.AzureSession]::ClientFactory.AddUserAgent("VSAzureTools-$UI$($host.name)".replace(' ','_'), '2.9.6')
+} catch { }
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3
+
+function Format-ValidationOutput {
+    param ($ValidationOutput, [int] $Depth = 0)
+    Set-StrictMode -Off
+    return @($ValidationOutput | Where-Object { $_ -ne $null } | ForEach-Object { @('  ' * $Depth + ': ' + $_.Message) + @(Format-ValidationOutput @($_.Details) ($Depth + 1)) })
+}
+
+$OptionalParameters = New-Object -TypeName Hashtable
+$TemplateFile = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, $TemplateFile))
+$TemplateParametersFile = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, $TemplateParametersFile))
+
+# Convert relative paths to absolute paths if needed
+$ArtifactStagingDirectory = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, $ArtifactStagingDirectory))
+$DSCSourceFolder = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, $DSCSourceFolder))
+
+# Parse the parameter file and update the values of artifacts location and artifacts location SAS token if they are present
+$JsonParameters = Get-Content $TemplateParametersFile -Raw | ConvertFrom-Json
+if (($JsonParameters | Get-Member -Type NoteProperty 'parameters') -ne $null) {
+    $JsonParameters = $JsonParameters.parameters
+}
+$ArtifactsLocationName = '_artifactsLocation'
+$ArtifactsLocationSasTokenName = '_artifactsLocationSasToken'
+$OptionalParameters[$ArtifactsLocationName] = $JsonParameters | Select -Expand $ArtifactsLocationName -ErrorAction Ignore | Select -Expand 'value' -ErrorAction Ignore
+$OptionalParameters[$ArtifactsLocationSasTokenName] = $JsonParameters | Select -Expand $ArtifactsLocationSasTokenName -ErrorAction Ignore | Select -Expand 'value' -ErrorAction Ignore
+
+# Create DSC configuration archive
+if (Test-Path $DSCSourceFolder) {
+    $DSCSourceFilePaths = @(Get-ChildItem $DSCSourceFolder -File -Filter '*.ps1' | ForEach-Object -Process {$_.FullName})
+    foreach ($DSCSourceFilePath in $DSCSourceFilePaths) {
+        $DSCArchiveFilePath = $DSCSourceFilePath.Substring(0, $DSCSourceFilePath.Length - 4) + '.zip'
+        Publish-AzureRmVMDscConfiguration $DSCSourceFilePath -OutputArchivePath $DSCArchiveFilePath -Force -Verbose
+    }
+}
+
+# Create a storage account name if none was provided
+if ($StorageAccountName -eq '') {
+    $StorageAccountName = 'stage' + ((Get-AzureRmContext).Subscription.SubscriptionId).Replace('-', '').substring(0, 19)
+}
+
+$StorageAccount = (Get-AzureRmStorageAccount | Where-Object{$_.StorageAccountName -eq $StorageAccountName})
+
+# Create the storage account if it doesn't already exist
+if ($StorageAccount -eq $null) {
+    $StorageResourceGroupName = 'ARM_Deploy_Staging'
+    New-AzureRmResourceGroup -Location "$ResourceGroupLocation" -Name $StorageResourceGroupName -Force
+    $StorageAccount = New-AzureRmStorageAccount -StorageAccountName $StorageAccountName -Type 'Standard_LRS' -ResourceGroupName $StorageResourceGroupName -Location "$ResourceGroupLocation"
+}
+
+# Generate the value for artifacts location if it is not provided in the parameter file
+if ($OptionalParameters[$ArtifactsLocationName] -eq $null) {
+    $OptionalParameters[$ArtifactsLocationName] = $StorageAccount.Context.BlobEndPoint + $StorageContainerName
+}
+
+# Copy files from the local storage staging location to the storage account container
+New-AzureStorageContainer -Name $StorageContainerName -Context $StorageAccount.Context -ErrorAction SilentlyContinue *>&1
+
+$ArtifactFilePaths = Get-ChildItem $ArtifactStagingDirectory -Recurse -File | ForEach-Object -Process {$_.FullName}
+foreach ($SourcePath in $ArtifactFilePaths) {
+    Set-AzureStorageBlobContent -File $SourcePath -Blob $SourcePath.Substring($ArtifactStagingDirectory.length + 1) `
+        -Container $StorageContainerName -Context $StorageAccount.Context -Force
+}
+
+# Generate a 4 hour SAS token for the artifacts location if one was not provided in the parameters file
+if ($OptionalParameters[$ArtifactsLocationSasTokenName] -eq $null) {
+    $OptionalParameters[$ArtifactsLocationSasTokenName] = ConvertTo-SecureString -AsPlainText -Force `
+        (New-AzureStorageContainerSASToken -Container $StorageContainerName -Context $StorageAccount.Context -Permission r -ExpiryTime (Get-Date).AddHours(4))
+}
+
+# Create or update the resource group using the specified template file and template parameters file
+New-AzureRmResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation -Verbose -Force
+
+if ($ValidateOnly) {
+    $ErrorMessages = Format-ValidationOutput (Test-AzureRmResourceGroupDeployment -ResourceGroupName $ResourceGroupName `
+                                                                                  -TemplateFile $TemplateFile `
+                                                                                  -TemplateParameterFile $TemplateParametersFile `
+                                                                                  @OptionalParameters)
+    if ($ErrorMessages) {
+        Write-Output '', 'Validation returned the following errors:', @($ErrorMessages), '', 'Template is invalid.'
+    }
+    else {
+        Write-Output '', 'Template is valid.'
+    }
+}
+else {
+    New-AzureRmResourceGroupDeployment -Name ((Get-ChildItem $TemplateFile).BaseName + '-' + ((Get-Date).ToUniversalTime()).ToString('MMdd-HHmm')) `
+                                       -ResourceGroupName $ResourceGroupName `
+                                       -TemplateFile $TemplateFile `
+                                       -TemplateParameterFile $TemplateParametersFile `
+                                       @OptionalParameters `
+                                       -Force -Verbose `
+                                       -ErrorVariable ErrorMessages
+    if ($ErrorMessages) {
+        Write-Output '', 'Template deployment returned the following errors:', @(@($ErrorMessages) | ForEach-Object { $_.Exception.Message.TrimEnd("`r`n") })
+    }
+}

--- a/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/Deployment.targets
+++ b/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/Deployment.targets
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <DebugSymbols>false</DebugSymbols>
+    <SkipCopyBuildProduct>true</SkipCopyBuildProduct>
+    <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
+    <TargetRuntime>None</TargetRuntime>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">obj\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition=" !HasTrailingSlash('$(BaseIntermediateOutputPath)') ">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
+    <ProjectReferencesOutputPath Condition=" '$(ProjectReferencesOutputPath)' == '' ">$(IntermediateOutputPath)ProjectReferences</ProjectReferencesOutputPath>
+    <ProjectReferencesOutputPath Condition=" !HasTrailingSlash('$(ProjectReferencesOutputPath)') ">$(ProjectReferencesOutputPath)\</ProjectReferencesOutputPath>
+    <StageArtifacts Condition=" '$(StageArtifacts)' == '' ">true</StageArtifacts>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DefineCommonItemSchemas>false</DefineCommonItemSchemas>
+    <DefineCommonCapabilities>false</DefineCommonCapabilities>
+  </PropertyGroup>
+
+  <ProjectExtensions>
+    <ProjectCapabilities>
+      <DeploymentProject />
+    </ProjectCapabilities>
+  </ProjectExtensions>
+
+  <ItemDefinitionGroup>
+    <Content>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <None>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </None>
+    <ProjectReference>
+      <Private>false</Private>
+      <Targets>Build</Targets>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+
+  <Target Name="CreateManifestResourceNames" />
+
+  <PropertyGroup>
+    <StageArtifactsDependsOn>
+      _GetDeploymentProjectContent;
+      _CalculateContentOutputRelativePaths;
+      _GetReferencedProjectsOutput;
+      _CalculateArtifactStagingDirectory;
+      _CopyOutputToArtifactStagingDirectory;
+    </StageArtifactsDependsOn>
+  </PropertyGroup>
+
+  <Target Name="_CopyOutputToArtifactStagingDirectory">
+    <Copy SourceFiles="@(DeploymentProjectContentOutput)" DestinationFiles="$(ArtifactStagingDirectory)\$(MSBuildProjectName)%(RelativePath)" />
+    <Copy SourceFiles="@(BuildProjectReferencesOutput)" DestinationFiles="$(ArtifactStagingDirectory)\$(MSBuildProjectName)\%(ProjectName)\%(RecursiveDir)%(FileName)%(Extension)" />
+  </Target>
+
+  <Target Name="_GetDeploymentProjectContent">
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="ContentFilesProjectOutputGroup">
+      <Output TaskParameter="TargetOutputs" ItemName="DeploymentProjectContentOutput" />
+    </MSBuild>
+  </Target>
+
+  <Target Name="_GetReferencedProjectsOutput">
+    <PropertyGroup>
+      <MsBuildProperties>Configuration=$(Configuration);Platform=$(Platform)</MsBuildProperties>
+    </PropertyGroup>
+
+    <MSBuild Projects="@(ProjectReference)"
+             BuildInParallel="$(BuildInParallel)"
+             Properties="$(MsBuildProperties)"
+             Targets="%(ProjectReference.Targets)" />
+
+    <ItemGroup>
+      <BuildProjectReferencesOutput Include="%(ProjectReference.IncludeFilePath)">
+        <ProjectName>$([System.IO.Path]::GetFileNameWithoutExtension('%(ProjectReference.Identity)'))</ProjectName>
+      </BuildProjectReferencesOutput>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_CalculateArtifactStagingDirectory" Condition=" '$(ArtifactStagingDirectory)'=='' ">
+    <PropertyGroup>
+      <ArtifactStagingDirectory Condition=" '$(OutDir)'!='' ">$(OutDir)</ArtifactStagingDirectory>
+      <ArtifactStagingDirectory Condition=" '$(ArtifactStagingDirectory)'=='' ">$(OutputPath)</ArtifactStagingDirectory>
+      <ArtifactStagingDirectory Condition=" !HasTrailingSlash('$(ArtifactStagingDirectory)') ">$(ArtifactStagingDirectory)\</ArtifactStagingDirectory>
+      <ArtifactStagingDirectory>$(ArtifactStagingDirectory)staging\</ArtifactStagingDirectory>
+      <ArtifactStagingDirectory Condition=" '$(Build_StagingDirectory)'!='' AND '$(TF_Build)'=='True' ">$(Build_StagingDirectory)</ArtifactStagingDirectory>
+    </PropertyGroup>
+  </Target>
+
+  <!-- Appends each of the deployment project's content output files with metadata indicating its relative path from the deployment project's folder. -->
+  <Target Name="_CalculateContentOutputRelativePaths"
+          Outputs="%(DeploymentProjectContentOutput.Identity)">
+    <PropertyGroup>
+      <_OriginalIdentity>%(DeploymentProjectContentOutput.Identity)</_OriginalIdentity>
+      <_RelativePath>$(_OriginalIdentity.Replace('$(MSBuildProjectDirectory)', ''))</_RelativePath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <DeploymentProjectContentOutput>
+        <RelativePath>$(_RelativePath)</RelativePath>
+      </DeploymentProjectContentOutput>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CoreCompile" />
+
+  <PropertyGroup>
+    <StageArtifactsAfterTargets Condition=" '$(StageArtifacts)' == 'true' ">
+      PrepareForRun
+    </StageArtifactsAfterTargets>
+  </PropertyGroup>
+
+  <Target Name="StageArtifacts" DependsOnTargets="$(StageArtifactsDependsOn)" AfterTargets="$(StageArtifactsAfterTargets)"/>
+
+  <!-- Custom target to clean up local deployment staging files -->
+  <Target Name="DeleteBinObjFolders" BeforeTargets="Clean">
+    <RemoveDir Directories="$(OutputPath)" />  
+    <RemoveDir Directories="$(BaseIntermediateOutputPath)" />
+  </Target>
+</Project>

--- a/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/SAP-Hana-IaaC-Existing-VNet.deployproj
+++ b/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/SAP-Hana-IaaC-Existing-VNet.deployproj
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|AnyCPU">
+      <Configuration>Debug</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|AnyCPU">
+      <Configuration>Release</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>419b88f6-074b-4e13-a333-4f459918b53c</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>Deployment</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>1.0</TargetFrameworkVersion>
+    <PrepareForBuildDependsOn>
+    </PrepareForBuildDependsOn>
+  </PropertyGroup>
+  <Import Condition=" Exists('Deployment.targets') " Project="Deployment.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+  <!-- vertag<:>start tokens<:>maj.min -->
+  <Import Condition=" Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Deployment\1.1\DeploymentProject.targets') " Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Deployment\1.1\DeploymentProject.targets" />
+  <!-- vertag<:>end -->
+  <ItemGroup>
+    <Content Include="azuredeploy.json" />
+    <Content Include="azuredeploy.parameters.json" />
+    <None Include="Deployment.targets">
+      <Visible>False</Visible>
+    </None>
+    <Content Include="Deploy-AzureResourceGroup.ps1" />
+    <Content Include="deploymentParameters\appsTier.parameters.json" />
+    <Content Include="deploymentParameters\dataTier.parameters.json" />
+    <Content Include="deploymentParameters\jumpbox.parameters.json" />
+    <Content Include="deploymentParameters\virtualNetwork.parameters.json" />
+    <Content Include="deploymentParameters\sharedSvcsTier.parameters.json" />
+    <Content Include="deploymentTemplates\appsTier.json" />
+    <Content Include="deploymentTemplates\dataTier.json" />
+    <Content Include="deploymentTemplates\jumpbox.json" />
+    <Content Include="deploymentTemplates\virtualNetwork.json" />
+    <Content Include="deploymentTemplates\sharedSvcsTier.json" />
+  </ItemGroup>
+  <Target Name="GetReferenceAssemblyPaths" />
+</Project>

--- a/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/azuredeploy.json
+++ b/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/azuredeploy.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "_artifactsLocation": {
+      "type": "string"
+    },
+    "_artifactsLocationSasToken": {
+      "type": "securestring"
+    }
+  },
+  "variables": {
+    "templateFolder": "deploymentTemplates",
+    "parametersFolder": "deploymentParameters",
+
+    // "virtualNetworkTemplateFileName": "virtualNetwork.json",
+    // "virtualNetworkTemplateParametersFileName": "virtualNetwork.parameters.json",
+
+    "jumpboxTemplateFileName": "jumpbox.json",
+    "jumpboxTemplateParametersFileName": "jumpbox.parameters.json",
+
+    "dataTierTemplateFileName": "dataTier.json",
+    "dataTierTemplateParametersFileName": "dataTier.parameters.json",
+
+    "appsTierTemplateFileName": "appsTier.json",
+    "appsTierTemplateParametersFileName": "appsTier.parameters.json",
+
+    "sharedSvcsTierTemplateFileName": "sharedSvcsTier.json",
+    "sharedSvcsTierTemplateParametersFileName": "sharedSvcsTier.parameters.json"
+  },
+  "resources": [
+    // {
+    //   "name": "virtualNetwork",
+    //   "type": "Microsoft.Resources/deployments",
+    //   "apiVersion": "2016-09-01",
+    //   "dependsOn": [],
+    //   "properties": {
+    //     "mode": "Incremental",
+    //     "templateLink": {
+    //       "uri": "[concat(parameters('_artifactsLocation'), '/', variables('templateFolder'), '/', variables('virtualNetworkTemplateFileName'), parameters('_artifactsLocationSasToken'))]",
+    //       "contentVersion": "1.0.0.0"
+    //     },
+    //     "parametersLink": {
+    //       "uri": "[concat(parameters('_artifactsLocation'), '/', variables('parametersFolder'), '/', variables('virtualNetworkTemplateParametersFileName'), parameters('_artifactsLocationSasToken'))]",
+    //       "contentVersion": "1.0.0.0"
+    //     }
+    //   }
+    // },
+    {
+      "name": "jumpbox",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2016-09-01",
+      "dependsOn": [
+        // "virtualNetwork"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('_artifactsLocation'), '/', variables('templateFolder'), '/', variables('jumpboxTemplateFileName'), parameters('_artifactsLocationSasToken'))]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parametersLink": {
+          "uri": "[concat(parameters('_artifactsLocation'), '/', variables('parametersFolder'), '/', variables('jumpboxTemplateParametersFileName'), parameters('_artifactsLocationSasToken'))]",
+          "contentVersion": "1.0.0.0"
+        }
+      }
+    },
+    {
+      "name": "dataTier",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2016-09-01",
+      "dependsOn": [
+        // "virtualNetwork"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('_artifactsLocation'), '/', variables('templateFolder'), '/', variables('dataTierTemplateFileName'), parameters('_artifactsLocationSasToken'))]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parametersLink": {
+          "uri": "[concat(parameters('_artifactsLocation'), '/', variables('parametersFolder'), '/', variables('dataTierTemplateParametersFileName'), parameters('_artifactsLocationSasToken'))]",
+          "contentVersion": "1.0.0.0"
+        }
+      }
+    },
+    {
+      "name": "appsTier",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2016-09-01",
+      "dependsOn": [
+        // "virtualNetwork"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('_artifactsLocation'), '/', variables('templateFolder'), '/', variables('appsTierTemplateFileName'), parameters('_artifactsLocationSasToken'))]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parametersLink": {
+          "uri": "[concat(parameters('_artifactsLocation'), '/', variables('parametersFolder'), '/', variables('appsTierTemplateParametersFileName'), parameters('_artifactsLocationSasToken'))]",
+          "contentVersion": "1.0.0.0"
+        }
+      }
+    },
+    {
+      "name": "sharedSvcsTier",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2016-09-01",
+      "dependsOn": [
+        // "virtualNetwork"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('_artifactsLocation'), '/', variables('templateFolder'), '/', variables('sharedSvcsTierTemplateFileName'), parameters('_artifactsLocationSasToken'))]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parametersLink": {
+          "uri": "[concat(parameters('_artifactsLocation'), '/', variables('parametersFolder'), '/', variables('sharedSvcsTierTemplateParametersFileName'), parameters('_artifactsLocationSasToken'))]",
+          "contentVersion": "1.0.0.0"
+        }
+      }
+    }
+  ],
+  "outputs": {  }
+}

--- a/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/azuredeploy.parameters.json
+++ b/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/azuredeploy.parameters.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+  }
+}

--- a/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/deploymentParameters/appsTier.parameters.json
+++ b/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/deploymentParameters/appsTier.parameters.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appsTierSettings": {
+      "value": {
+        "name": "appsTier",
+        "vmSettings": {
+          "vmName": "sapErpCI",
+          "virtualNetworkName": "SAPNetwork",
+          "virtualNetworkRG": "SAPShared",
+          "subnetName": "apps",
+          "privateIpAddresses": [
+            "10.0.2.4",
+            "10.0.2.5"
+          ],
+          "vmSize": "Standard_DS11_v2",
+          "vmUsername": "adminuser",
+          "vmPassword": "P@ssw0rd1234",
+          "image": {
+            "publisher": "Redhat",
+            "offer": "RHEL",
+            "sku": "7.2",
+            "version": "latest"
+          }
+        },
+        "stgAccountNamePrefix": "sapstg"
+      }
+    }
+  }
+}

--- a/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/deploymentParameters/dataTier.parameters.json
+++ b/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/deploymentParameters/dataTier.parameters.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataTierSettings": {
+      "value": {
+        "name": "dataTier",
+        "vmSettings": {
+          "vmName": "sapHanaDB",
+          "virtualNetworkName": "SAPNetwork",
+          "virtualNetworkRG": "SAPShared",
+          "subnetName": "data",
+          "privateIpAddresses": [
+            "10.0.3.4",
+            "10.0.3.5"
+          ],
+          "vmSize": "Standard_GS3",
+          "vmUsername": "adminuser",
+          "vmPassword": "P@ssw0rd1234",
+          "image": {
+            "publisher": "Redhat",
+            "offer": "RHEL",
+            "sku": "7.2",
+            "version": "latest"
+          },
+          "dataDiskSizeGB": "512"
+        },
+        "stgAccountNamePrefix": "sapstg"
+      }
+    }
+  }
+}

--- a/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/deploymentParameters/jumpbox.parameters.json
+++ b/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/deploymentParameters/jumpbox.parameters.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "jumpboxSettings": {
+      "value": {
+        "virtualNetworkName": "SAPNetwork",
+        "virtualNetworkRG": "SAPShared",
+        "subnetName": "mgmt",
+        "vmName": "jumpbox",
+        "vmSize": "Standard_A1",
+        "vmUsername": "adminuser",
+        "vmPassword": "P@ssw0rd1234",
+        "image": {
+          "publisher": "Canonical",
+          "offer": "UbuntuServer",
+          "sku": "16.04-LTS",
+          "version": "latest"
+        }
+      }
+    }
+  }
+}

--- a/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/deploymentParameters/sharedSvcsTier.parameters.json
+++ b/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/deploymentParameters/sharedSvcsTier.parameters.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "sharedSvcsTierSettings": {
+      "value": {
+        "name": "sharedSvcsTier",
+        "virtualNetworkName": "SAPNetwork",
+        "virtualNetworkRG": "SAPShared",
+        "subnetName": "sharedSvcs",
+        "winClientVmSettings": {
+          "vmName": "winClientVM",
+          "vmSize": "Standard_DS11",
+          "vmUsername": "adminuser",
+          "vmPassword": "P@ssw0rd1234",
+          "image": {
+            "publisher": "MicrosoftWindowsServer",
+            "offer": "WindowsServer",
+            "sku": "2012-R2-Datacenter",
+            "version": "latest"
+          }
+        }
+      }
+    }
+  }
+}

--- a/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/deploymentTemplates/appsTier.json
+++ b/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/deploymentTemplates/appsTier.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appsTierSettings": {
+      "type": "object",
+      "metadata": {
+        "description": "Settings for the apps tier"
+      }
+    }
+  },
+  "variables": {
+    "vmNicName": "[concat(parameters('appsTierSettings').vmSettings.vmName, 'Nic')]",
+    "vnetId": "[resourceId(parameters('appsTierSettings').vmSettings.virtualNetworkRG, 'Microsoft.Network/virtualNetworks', parameters('appsTierSettings').vmSettings.virtualNetworkName)]",
+    "vmSubnetRef": "[concat(variables('vnetId'),'/subnets/',parameters('appsTierSettings').vmSettings.subnetName)]",
+    "stgAccountName": "[concat(parameters('appsTierSettings').stgAccountNamePrefix, uniqueString(resourceGroup().id))]"
+  },
+  "resources": [
+    {
+      "name": "[concat(variables('vmNicName'), '-', copyIndex(1))]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2016-03-30",
+      "dependsOn": [],
+      "tags": {
+        "displayName": "[concat(variables('vmNicName'), '-', copyIndex(1))]"
+      },
+      "copy": {
+        "name": "vmNicCopy",
+        "count": 2
+      },
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "[parameters('appsTierSettings').vmSettings.privateIpAddresses[copyIndex()]]",
+              "subnet": {
+                "id": "[variables('vmSubnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "[parameters('appsTierSettings').vmSettings.vmName]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2016-04-30-preview",
+      "dependsOn": [
+        "vmNicCopy",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('stgAccountName'))]"
+      ],
+      "tags": {
+        "displayName": "[parameters('appsTierSettings').vmSettings.vmName]"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('appsTierSettings').vmSettings.vmSize]"
+        },
+        "osProfile": {
+          "computerName": "[parameters('appsTierSettings').vmSettings.vmName]",
+          "adminUsername": "[parameters('appsTierSettings').vmSettings.vmUsername]",
+          "adminPassword": "[parameters('appsTierSettings').vmSettings.vmPassword]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('appsTierSettings').vmSettings.image.publisher]",
+            "offer": "[parameters('appsTierSettings').vmSettings.image.offer]",
+            "sku": "[parameters('appsTierSettings').vmSettings.image.sku]",
+            "version": "[parameters('appsTierSettings').vmSettings.image.version]"
+          },
+          "osDisk": {
+            "name": "[concat(parameters('appsTierSettings').vmSettings.vmName, '-OSDisk')]",
+            "caching": "ReadWrite",
+            "createOption": "FromImage",
+            "vhd": {
+              "uri": "[concat('https://', variables('stgAccountName'), '.blob.core.windows.net/vhds/', parameters('appsTierSettings').vmSettings.vmName, '-OSDisk.vhd')]"
+            }
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmNicName'), '-1'))]",
+              "properties": {
+                "primary": true
+              }
+            },
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmNicName'), '-2'))]",
+              "properties": {
+                "primary": false
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "[variables('stgAccountName')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-06-15",
+      "dependsOn": [],
+      "tags": {
+        "displayName": "stg"
+      },
+      "properties": {
+        "accountType": "Premium_LRS"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/deploymentTemplates/dataTier.json
+++ b/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/deploymentTemplates/dataTier.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataTierSettings": {
+      "type": "object",
+      "metadata": {
+        "description": "Settings for the data tier"
+      }
+    }
+  },
+  "variables": {
+    "vmNicName": "[concat(parameters('dataTierSettings').vmSettings.vmName, 'Nic')]",
+    "vnetId": "[resourceId(parameters('dataTierSettings').vmSettings.virtualNetworkRG, 'Microsoft.Network/virtualNetworks', parameters('dataTierSettings').vmSettings.virtualNetworkName)]",
+    "vmSubnetRef": "[concat(variables('vnetId'),'/subnets/',parameters('dataTierSettings').vmSettings.subnetName)]",
+    "stgAccountName": "[concat(parameters('dataTierSettings').stgAccountNamePrefix, uniqueString(resourceGroup().id))]"
+  },
+  "resources": [
+    {
+      "name": "[concat(variables('vmNicName'), '-', copyIndex(1))]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2016-03-30",
+      "dependsOn": [],
+      "tags": {
+        "displayName": "[concat(variables('vmNicName'), '-', copyIndex(1))]"
+      },
+      "copy": {
+        "name": "vmNicCopy",
+        "count": 2
+      },
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "[parameters('dataTierSettings').vmSettings.privateIpAddresses[copyIndex()]]",
+              "subnet": {
+                "id": "[variables('vmSubnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "[parameters('dataTierSettings').vmSettings.vmName]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2016-04-30-preview",
+      "dependsOn": [
+        "vmNicCopy",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('stgAccountName'))]"
+      ],
+      "tags": {
+        "displayName": "[parameters('dataTierSettings').vmSettings.vmName]"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('dataTierSettings').vmSettings.vmSize]"
+        },
+        "osProfile": {
+          "computerName": "[parameters('dataTierSettings').vmSettings.vmName]",
+          "adminUsername": "[parameters('dataTierSettings').vmSettings.vmUsername]",
+          "adminPassword": "[parameters('dataTierSettings').vmSettings.vmPassword]",
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('dataTierSettings').vmSettings.image.publisher]",
+            "offer": "[parameters('dataTierSettings').vmSettings.image.offer]",
+            "sku": "[parameters('dataTierSettings').vmSettings.image.sku]",
+            "version": "[parameters('dataTierSettings').vmSettings.image.version]"
+          },
+          "osDisk": {
+            "name": "[concat(parameters('dataTierSettings').vmSettings.vmName, '-OSDisk')]",
+            "caching": "ReadWrite",
+            "createOption": "FromImage",
+            "vhd": {
+              "uri": "[concat('https://', variables('stgAccountName'), '.blob.core.windows.net/vhds/', parameters('dataTierSettings').vmSettings.vmName, '-OSDisk.vhd')]"
+            }
+          },
+          "dataDisks": [
+            {
+              "name": "[concat(parameters('dataTierSettings').vmSettings.vmName, '-DataDisk-01')]",
+              "caching": "None",
+              "lun": 0,
+              "diskSizeGB": "[parameters('dataTierSettings').vmSettings.dataDiskSizeGB]",
+              "createOption": "Empty",
+              "vhd": {
+                "uri": "[concat('https://', variables('stgAccountName'), '.blob.core.windows.net/vhds/', parameters('dataTierSettings').vmSettings.vmName, '-DataDisk-01.vhd')]"
+              }
+            },
+            {
+              "name": "[concat(parameters('dataTierSettings').vmSettings.vmName, '-DataDisk-02')]",
+              "caching": "None",
+              "lun": 1,
+              "diskSizeGB": "[parameters('dataTierSettings').vmSettings.dataDiskSizeGB]",
+              "createOption": "Empty",
+              "vhd": {
+                "uri": "[concat('https://', variables('stgAccountName'), '.blob.core.windows.net/vhds/', parameters('dataTierSettings').vmSettings.vmName, '-DataDisk-02.vhd')]"
+              }
+            },
+            {
+              "name": "[concat(parameters('dataTierSettings').vmSettings.vmName, '-DataDisk-03')]",
+              "caching": "None",
+              "lun": 2,
+              "diskSizeGB": "[parameters('dataTierSettings').vmSettings.dataDiskSizeGB]",
+              "createOption": "Empty",
+              "vhd": {
+                "uri": "[concat('https://', variables('stgAccountName'), '.blob.core.windows.net/vhds/', parameters('dataTierSettings').vmSettings.vmName, '-DataDisk-03.vhd')]"
+              }
+            },
+            {
+              "name": "[concat(parameters('dataTierSettings').vmSettings.vmName, '-DataDisk-04')]",
+              "caching": "None",
+              "lun": 3,
+              "diskSizeGB": "[parameters('dataTierSettings').vmSettings.dataDiskSizeGB]",
+              "createOption": "Empty",
+              "vhd": {
+                "uri": "[concat('https://', variables('stgAccountName'), '.blob.core.windows.net/vhds/', parameters('dataTierSettings').vmSettings.vmName, '-DataDisk-04.vhd')]"
+              }
+            }
+          ]
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmNicName'), '-1'))]",
+              "properties": {
+                "primary": true
+              }
+            },
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmNicName'), '-2'))]",
+              "properties": {
+                "primary": false
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "[variables('stgAccountName')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-06-15",
+      "dependsOn": [],
+      "tags": {
+        "displayName": "stg"
+      },
+      "properties": {
+        "accountType": "Premium_LRS"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/deploymentTemplates/jumpbox.json
+++ b/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/deploymentTemplates/jumpbox.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "jumpboxSettings": {
+      "type": "object",
+      "metadata": {
+        "description": "Settings for jumpbox (bastion host)"
+      }
+    }
+  },
+  "variables": {
+    "vnetId": "[resourceId(parameters('jumpboxSettings').virtualNetworkRG, 'Microsoft.Network/virtualNetworks', parameters('jumpboxSettings').virtualNetworkName)]",
+    "jumpboxSubnetRef": "[concat(variables('vnetId'),'/subnets/',parameters('jumpboxSettings').subnetName)]",
+    "jumpboxPipDnsName": "[concat(parameters('jumpboxSettings').vmName, '-', uniqueString(resourceGroup().id))]",
+    "jumpboxNicName": "[concat(parameters('jumpboxSettings').vmName, 'Nic')]",
+    "jumpboxPipName": "[concat(parameters('jumpboxSettings').vmName, 'Pip')]"
+  },
+  "resources": [
+    {
+      "name": "[variables('jumpboxNicName')]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2016-03-30",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/publicIPAddresses', variables('jumpboxPipName'))]"
+      ],
+      "tags": {
+        "displayName": "jumpboxNic"
+      },
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('jumpboxSubnetRef')]"
+              },
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('jumpboxPipName'))]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "[parameters('jumpboxSettings').vmName]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2016-04-30-preview",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkInterfaces', variables('jumpboxNicName'))]"
+      ],
+      "tags": {
+        "displayName": "jumpbox"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('jumpboxSettings').vmSize]"
+        },
+        "osProfile": {
+          "computerName": "[parameters('jumpboxSettings').vmName]",
+          "adminUsername": "[parameters('jumpboxSettings').vmUsername]",
+          "adminPassword": "[parameters('jumpboxSettings').vmPassword]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('jumpboxSettings').image.publisher]",
+            "offer": "[parameters('jumpboxSettings').image.offer]",
+            "sku": "[parameters('jumpboxSettings').image.sku]",
+            "version": "[parameters('jumpboxSettings').image.version]"
+          },
+          "osDisk": {
+            "name": "[concat(parameters('jumpboxSettings').vmName, 'OSDisk')]",
+            "managedDisk": {
+              "storageAccountType": "Standard_LRS"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('jumpboxNicName'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "[variables('jumpboxPipName')]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2016-03-30",
+      "dependsOn": [],
+      "tags": {
+        "displayName": "jumpboxPip"
+      },
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "[variables('jumpboxPipDnsName')]"
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "vmUsername": {
+      "value": "[parameters('jumpboxSettings').vmUsername]",
+      "type": "string"
+    },
+    "vmPassword": {
+      "value": "[parameters('jumpboxSettings').vmPassword]",
+      "type": "string"
+    }
+  }
+}

--- a/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/deploymentTemplates/sharedSvcsTier.json
+++ b/SAP-Hana-IaaC/SAP-Hana-IaaC-Existing-VNet/deploymentTemplates/sharedSvcsTier.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "sharedSvcsTierSettings": {
+      "type": "object",
+      "metadata": {
+        "description": "Settings for the shared services tier"
+      }
+    }
+  },
+  "variables": {
+    "vnetId": "[resourceId(parameters('sharedSvcsTierSettings').virtualNetworkRG, 'Microsoft.Network/virtualNetworks', parameters('sharedSvcsTierSettings').virtualNetworkName)]",
+    "vmSubnetRef": "[concat(variables('vnetId'),'/subnets/',parameters('sharedSvcsTierSettings').subnetName)]",
+    "winClientVmNicName": "[concat(parameters('sharedSvcsTierSettings').winClientVmSettings.vmName, 'Nic')]"
+  },
+  "resources": [
+    {
+      "name": "[variables('winClientVmNicName')]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2016-03-30",
+      "dependsOn": [],
+      "tags": {
+        "displayName": "[variables('winClientVmNicName')]"
+      },
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('vmSubnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "[parameters('sharedSvcsTierSettings').winClientVmSettings.vmName]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2016-04-30-preview",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('winClientVmNicName'))]"
+      ],
+      "tags": {
+        "displayName": "[parameters('sharedSvcsTierSettings').winClientVmSettings.vmName]"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('sharedSvcsTierSettings').winClientVmSettings.vmSize]"
+        },
+        "osProfile": {
+          "computerName": "[parameters('sharedSvcsTierSettings').winClientVmSettings.vmName]",
+          "adminUsername": "[parameters('sharedSvcsTierSettings').winClientVmSettings.vmUsername]",
+          "adminPassword": "[parameters('sharedSvcsTierSettings').winClientVmSettings.vmPassword]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('sharedSvcsTierSettings').winClientVmSettings.image.publisher]",
+            "offer": "[parameters('sharedSvcsTierSettings').winClientVmSettings.image.offer]",
+            "sku": "[parameters('sharedSvcsTierSettings').winClientVmSettings.image.sku]",
+            "version": "[parameters('sharedSvcsTierSettings').winClientVmSettings.image.version]"
+          },
+          "osDisk": {
+            "name": "[concat(parameters('sharedSvcsTierSettings').winClientVmSettings.vmName, '-OSDisk')]",
+            "caching": "ReadWrite",
+            "createOption": "FromImage",
+            "managedDisk": {
+              "storageAccountType": "Standard_LRS"
+            }
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('winClientVmNicName')))]"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "outputs": {}
+}


### PR DESCRIPTION
Ross and Ben had a second scenario they needed - to support an existing VNet. I didn't want to do major refactoring, so what I did was remove the vnet nested deployment (+parameters) and tweaked the parameters files to support a virtualNetworkRG in addition to name. The user can then set the parameters in a way that it will use an existing VNet in a separate RG. 

Opening up a PR in case you want to consolidate back into your repo for future edits. Thanks!